### PR TITLE
feat: honor Retry-After header on foreman rate-limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* [FEATURE] honor the Retry-After header (delay-seconds and HTTP-date) when foreman rate-limits the client
+* [FEATURE] add `--retry-max` flag to configure the foreman client max retries
+
+
 ## 0.0.7 / 2024-04-167
 
 * [FEATURE] go 1.22

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Flags:
       --password=PASSWORD        Foreman password ($FOREMAN_PASSWORD)
       --[no-]skip-tls-verify     Foreman skip TLS verify. ($FOREMAN_SKIP_TLS_VERIFY)
       --concurrency=4            Max concurrent foreman client http request.
+      --retry-max=3              Max retries for foreman client http requests (honors the Retry-After header on rate-limit responses).
       --limit=0                  Foreman client host limit search.
       --search=""                Foreman client host search filter.
       --timeout-offset=0.5s      Offset to subtract from Prometheus-supplied timeout.

--- a/foreman/foreman.go
+++ b/foreman/foreman.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -183,7 +184,56 @@ func (l *LeveledLogrus) Warn(msg string, keysAndValues ...interface{}) {
 	l.WithFields(fields(keysAndValues)).Warn(msg)
 }
 
-func NewHTTPClient(baseURL *url.URL, username, password string, skipTLSVerify bool, concurrency, limit int64, search, searchHostFact string, includeHostFactRegex, excludeHostFactRegex *regexp.Regexp, log *logrus.Logger) *HTTPClient {
+// retryAfterBackoff honors the Retry-After response header sent by Foreman
+// when it rate-limits the client (HTTP 429 Too Many Requests or 503 Service
+// Unavailable) before falling back to retryablehttp's exponential backoff.
+// Unlike retryablehttp.DefaultBackoff, it accepts both forms of the header
+// allowed by RFC 7231: delay-seconds ("120") and HTTP-date.
+func retryAfterBackoff(log *logrus.Logger) retryablehttp.Backoff {
+	return func(minWait, maxWait time.Duration, attemptNum int, resp *http.Response) time.Duration {
+		if resp != nil {
+			switch resp.StatusCode {
+			case http.StatusTooManyRequests, http.StatusServiceUnavailable:
+				if sleep, ok := parseRetryAfter(resp.Header.Get("Retry-After")); ok {
+					if log != nil {
+						log.WithFields(logrus.Fields{
+							"status":      resp.StatusCode,
+							"retry_after": sleep.String(),
+							"attempt":     attemptNum,
+						}).Warn("honoring Retry-After header from foreman")
+					}
+					return sleep
+				}
+			}
+		}
+		return retryablehttp.DefaultBackoff(minWait, maxWait, attemptNum, resp)
+	}
+}
+
+// parseRetryAfter parses a Retry-After header value in either the delay-seconds
+// ("120") or the HTTP-date ("Wed, 21 Oct 2015 07:28:00 GMT") form. It returns
+// false when the header is empty or malformed.
+func parseRetryAfter(v string) (time.Duration, bool) {
+	if v == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs < 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d, true
+		}
+		// The date is in the past, retry immediately.
+		return 0, true
+	}
+	return 0, false
+}
+
+func NewHTTPClient(baseURL *url.URL, username, password string, skipTLSVerify bool, concurrency, limit, retryMax int64, search, searchHostFact string, includeHostFactRegex, excludeHostFactRegex *regexp.Regexp, log *logrus.Logger) *HTTPClient {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipTLSVerify}, // #nosec G402
 	}
@@ -197,7 +247,8 @@ func NewHTTPClient(baseURL *url.URL, username, password string, skipTLSVerify bo
 
 	client := retryablehttp.NewClient()
 	client.HTTPClient.Transport = roundTripper
-	client.RetryMax = 3
+	client.RetryMax = int(retryMax)
+	client.Backoff = retryAfterBackoff(log)
 
 	if log == nil {
 		client.Logger = nil

--- a/foreman/foreman_test.go
+++ b/foreman/foreman_test.go
@@ -1,0 +1,46 @@
+package foreman
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		wantOK   bool
+		wantWait time.Duration
+	}{
+		{name: "empty", value: "", wantOK: false},
+		{name: "delay seconds", value: "120", wantOK: true, wantWait: 120 * time.Second},
+		{name: "zero seconds", value: "0", wantOK: true, wantWait: 0},
+		{name: "negative seconds", value: "-1", wantOK: false},
+		{name: "not a number", value: "soon", wantOK: false},
+		{name: "http-date in the past", value: "Wed, 21 Oct 2015 07:28:00 GMT", wantOK: true, wantWait: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseRetryAfter(tc.value)
+			if ok != tc.wantOK {
+				t.Fatalf("parseRetryAfter(%q) ok = %v, want %v", tc.value, ok, tc.wantOK)
+			}
+			if ok && got != tc.wantWait {
+				t.Fatalf("parseRetryAfter(%q) = %v, want %v", tc.value, got, tc.wantWait)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfterHTTPDateFuture(t *testing.T) {
+	future := time.Now().Add(1 * time.Hour).UTC().Format(http.TimeFormat)
+	got, ok := parseRetryAfter(future)
+	if !ok {
+		t.Fatalf("parseRetryAfter(%q) ok = false, want true", future)
+	}
+	if got <= 0 || got > time.Hour {
+		t.Fatalf("parseRetryAfter(%q) = %v, want a positive duration up to ~1h", future, got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ var (
 	skipTLSVerify = kingpin.Flag("skip-tls-verify", "Foreman skip TLS verify.").Envar("FOREMAN_SKIP_TLS_VERIFY").Bool()
 
 	concurrency   = kingpin.Flag("concurrency", "Max concurrent foreman client http request.").Default("4").Int64()
+	retryMax      = kingpin.Flag("retry-max", "Max retries for foreman client http requests (honors the Retry-After header on rate-limit responses).").Default("3").Int64()
 	limit         = kingpin.Flag("limit", "Foreman client host limit search.").Default("0").Int64()
 	search        = kingpin.Flag("search", "Foreman client host search filter.").Default("").String()
 	timeoutOffset = kingpin.Flag("timeout-offset", "Offset to subtract from Prometheus-supplied timeout.").Default("0.5s").Duration()
@@ -182,6 +183,7 @@ func main() {
 		*skipTLSVerify,
 		*concurrency,
 		*limit,
+		*retryMax,
 		*search,
 		*collectorHostFactSearch,
 		*collectorHostFactIncludeRegex,


### PR DESCRIPTION
## Context

Foreman rate-limits calls (`429 Too Many Requests`, sometimes `503`) with a `Retry-After` header. Under a rate-limit burst, the hardcoded 3 retries were exhausted: some pages never came back and the cache ended up **partially invalid**.

`go-retryablehttp` v0.7.5 already retries on 429 and honors `Retry-After`, but **only in the integer (seconds) form** — the RFC 7231 HTTP-date form is ignored.

## Changes

- **Custom `Backoff`** (`retryAfterBackoff`): honors `Retry-After` on 429/503 in **both forms** (delay-seconds *and* HTTP-date), logs it (`status`, `retry_after`, `attempt`), and falls back to the default exponential backoff otherwise.
- **Configurable `RetryMax`** via the new `--retry-max` flag (default `3`) to absorb rate-limit bursts without exhausting retries.
- Unit tests for `parseRetryAfter` (seconds, `0`, negative/invalid, past/future HTTP-date).
- README + CHANGELOG updated.

## Note

A higher `--retry-max` improves resilience, but each rate-limited page waits for the server-provided delay: mind the headroom left by `X-Prometheus-Scrape-Timeout-Seconds` / `--collector.host.timeout` (default `30s`).