### PR TITLE
feat: add foreman_exporter_client_retry_after_seconds metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [ENHANCEMENT] replace golang.org/x/exp/slices with stdlib slices and github.com/pkg/errors with fmt.Errorf
 * [FEATURE] honor the Retry-After header (delay-seconds and HTTP-date) when foreman rate-limits the client
 * [FEATURE] add `--retry-max` flag to configure the foreman client max retries
+* [FEATURE] add `foreman_exporter_client_retry_after_seconds` histogram (labeled by status) for honored Retry-After delays
 
 
 ## 0.0.7 / 2024-04-167

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ foreman_exporter_client_request_duration_seconds_count 74
 # HELP foreman_exporter_client_requests_total A counter for all requests from the foreman client.
 # TYPE foreman_exporter_client_requests_total counter
 foreman_exporter_client_requests_total{code="200",method="get"} 74
+# HELP foreman_exporter_client_retry_after_seconds A histogram of Retry-After delays honored from foreman rate-limit responses.
+# TYPE foreman_exporter_client_retry_after_seconds histogram
+foreman_exporter_client_retry_after_seconds_sum{status="429"} 4
+foreman_exporter_client_retry_after_seconds_count{status="429"} 2
 ```
 
 **Foreman hosts status**

--- a/foreman/foreman.go
+++ b/foreman/foreman.go
@@ -75,6 +75,14 @@ var (
 		},
 		[]string{"status"},
 	)
+	retryAfterMetric = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "foreman_exporter_client_retry_after_seconds",
+			Help:    "A histogram of Retry-After delays honored from foreman rate-limit responses.",
+			Buckets: []float64{1, 2, 5, 10, 30, 60, 120, 300, 600},
+		},
+		[]string{"status"},
+	)
 	UserAgent = fmt.Sprintf("foreman_exporter/%s", version.Version)
 )
 
@@ -84,6 +92,7 @@ func init() {
 		counterMetric,
 		histVecMetric,
 		inFlightGaugeMetric,
+		retryAfterMetric,
 	)
 }
 
@@ -195,6 +204,7 @@ func retryAfterBackoff(log *logrus.Logger) retryablehttp.Backoff {
 			switch resp.StatusCode {
 			case http.StatusTooManyRequests, http.StatusServiceUnavailable:
 				if sleep, ok := parseRetryAfter(resp.Header.Get("Retry-After")); ok {
+					retryAfterMetric.WithLabelValues(strconv.Itoa(resp.StatusCode)).Observe(sleep.Seconds())
 					if log != nil {
 						log.WithFields(logrus.Fields{
 							"status":      resp.StatusCode,

--- a/foreman/foreman_test.go
+++ b/foreman/foreman_test.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 // newTestClient builds an HTTPClient pointed at ts with no retries and no logger.
@@ -139,6 +141,27 @@ func TestParseRetryAfter(t *testing.T) {
 				t.Fatalf("parseRetryAfter(%q) = %v, want %v", tc.value, got, tc.wantWait)
 			}
 		})
+	}
+}
+
+func TestRetryAfterBackoffObservesMetric(t *testing.T) {
+	bo := retryAfterBackoff(nil)
+
+	resp429 := &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}}
+	resp429.Header.Set("Retry-After", "5")
+	if got := bo(0, 0, 0, resp429); got != 5*time.Second {
+		t.Fatalf("backoff(429) = %v, want 5s", got)
+	}
+
+	resp503 := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{}}
+	resp503.Header.Set("Retry-After", "10")
+	if got := bo(0, 0, 0, resp503); got != 10*time.Second {
+		t.Fatalf("backoff(503) = %v, want 10s", got)
+	}
+
+	// One histogram series per honored status; only this test observes it.
+	if n := testutil.CollectAndCount(retryAfterMetric); n != 2 {
+		t.Fatalf("retryAfterMetric series = %d, want 2 (429 and 503)", n)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/hashicorp/serf v0.10.4 // indirect
 	github.com/jaegertracing/jaeger-idl v0.9.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.23 // indirect
 	github.com/mdlayher/socket v0.6.1 // indirect


### PR DESCRIPTION
## Context

Retry-After handling (`retryAfterBackoff`/`parseRetryAfter` in `foreman/foreman.go`) was only
observable via a warning log or indirectly via `foreman_exporter_client_requests_total{code="429"}`.
This adds a dedicated metric so honored Retry-After delays are directly graphable/alertable.

## Change

- New histogram `foreman_exporter_client_retry_after_seconds` (labeled by `status`, i.e. 429/503),
  observed in `retryAfterBackoff` each time a Retry-After delay is honored. Buckets:
  `1,2,5,10,30,60,120,300,600` seconds. Registered in the client's `init()`.
- Gives the delay distribution plus `_count` (times honored) and `_sum` (total seconds waited).

Example query:
```promql
rate(foreman_exporter_client_retry_after_seconds_count{status="429"}[5m])
```

## Verification

- `go build`, `go vet`, `go test ./...` (29 pass — new test drives the backoff closure with 429
  and 503 responses, asserts the honored delay and that the histogram recorded both series).
- golangci-lint v2: 0 issues.
- Live: mock Foreman returning `429` + `Retry-After: 2`; after a scrape, `/metrics` shows
  `foreman_exporter_client_retry_after_seconds_bucket{status="429",le="2"} 2`.