### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0 / 2026-07-28
 
 * [CHANGE] go 1.26 and refresh all Go dependencies (dskit, prometheus/common v0.70, exporter-toolkit v0.17, client_golang v1.23)
 * [CHANGE] migrate logging from go-kit/promlog to log/slog (promslog); dskit keeps go-kit via an internal slog adapter so all output stays unified


### PR DESCRIPTION
Cut the **1.0.0** release: renames the CHANGELOG `Unreleased` section to `1.0.0 / 2026-07-28`.

1.0.0 gathers everything merged since 0.0.7 (2024):
- Go 1.26 + full dependency refresh
- logging migrated to log/slog (promslog) with a dskit go-kit adapter
- golangci-lint v2
- collectors' KV cache stored as a protobuf value (drops json-iterator)
- Retry-After header handling + `--retry-max` flag + `foreman_exporter_client_retry_after_seconds` metric

After merge, tagging `v1.0.0` on main triggers the `publish_release` job (promu/promci) to build and publish the release artifacts.