### PR TITLE
fix: stop goroutine leak and restore cluster re-convergence

### DIFF
--- a/cache_codec.go
+++ b/cache_codec.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/dskit/kv/codec"
 	"github.com/grafana/dskit/kv/memberlist"
+	"github.com/klauspost/compress/zstd"
 )
 
 // cacheCodec serializes Cache values for the collectors' memberlist KV keys.
@@ -14,6 +15,16 @@ import (
 // codec the ring itself uses, and stores the compressed payload as raw bytes
 // rather than a base64/quoted JSON string.
 var cacheCodec = codec.NewProtoCodec("cacheProtoCodec", func() proto.Message { return &Cache{} })
+
+// Shared, reusable zstd encoder/decoder for the collectors' cache payloads.
+// zstd.NewWriter/NewReader each spawn worker goroutines that live until Close();
+// creating them per cache operation (and never closing them, as the old code did)
+// leaks GOMAXPROCS goroutines on every scrape. EncodeAll/DecodeAll are safe for
+// concurrent use, so a single shared instance is created once and reused.
+var (
+	zstdEncoder, _ = zstd.NewWriter(nil)
+	zstdDecoder, _ = zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
+)
 
 // Merge implements memberlist.Mergeable. A single writer (the ring leader) owns
 // each key, so there is never a genuine multi-writer conflict to reconcile;

--- a/host_collector.go
+++ b/host_collector.go
@@ -11,8 +11,6 @@ import (
 	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/klauspost/compress/zstd"
-
 	"github.com/fgouteroux/foreman_exporter/foreman"
 )
 
@@ -88,8 +86,7 @@ func (c HostCollector) Collect(ch chan<- prometheus.Metric) {
 				content := cached.(*Cache).Content
 				// zstd decompress data
 				if c.CacheConfig.Compression {
-					decoder, _ := zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
-					decoded, err := decoder.DecodeAll(content, make([]byte, 0, len(content)))
+					decoded, err := zstdDecoder.DecodeAll(content, make([]byte, 0, len(content)))
 					if err != nil {
 						c.Logger.Error(fmt.Sprintf("Failed to decompress key '%s' value from kvStore", hostsKey), "err", err)
 						hostCollectorScrapeError(ch, 1.0)
@@ -198,8 +195,7 @@ func (c HostCollector) Collect(ch chan<- prometheus.Metric) {
 					content, _ := json.Marshal(hostsData)
 					if c.CacheConfig.Compression {
 						// use zstd to compress data
-						encoder, _ := zstd.NewWriter(nil)
-						content = encoder.EncodeAll(content, make([]byte, 0, len(content)))
+						content = zstdEncoder.EncodeAll(content, make([]byte, 0, len(content)))
 					}
 					if hostStatusError == nil {
 						// update the cache

--- a/hostfact_collector.go
+++ b/hostfact_collector.go
@@ -11,8 +11,6 @@ import (
 	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/klauspost/compress/zstd"
-
 	"github.com/fgouteroux/foreman_exporter/foreman"
 )
 
@@ -72,8 +70,7 @@ func (c HostFactCollector) Collect(ch chan<- prometheus.Metric) {
 				content := cc.Content
 				// zstd decompress data
 				if c.CacheConfig.Compression {
-					decoder, _ := zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
-					decoded, err := decoder.DecodeAll(content, make([]byte, 0, len(content)))
+					decoded, err := zstdDecoder.DecodeAll(content, make([]byte, 0, len(content)))
 					if err != nil {
 						c.Logger.Error(fmt.Sprintf("Failed to decompress key '%s' value from kvStore", hostsFactsKey), "err", err)
 						hostFactCollectorScrapeError(ch, 1.0)
@@ -168,8 +165,7 @@ func (c HostFactCollector) Collect(ch chan<- prometheus.Metric) {
 					content, _ := json.Marshal(hostsData)
 					if c.CacheConfig.Compression {
 						// use zstd to compress data
-						encoder, _ := zstd.NewWriter(nil)
-						content = encoder.EncodeAll(content, make([]byte, 0, len(content)))
+						content = zstdEncoder.EncodeAll(content, make([]byte, 0, len(content)))
 					}
 					if hostsFactsError == nil {
 						// update the cache

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func main() {
 			collectorCacheExpiresTTL = *collectorHostFactCacheExpiresTTL
 		}
 
-		logger.Info("collector host fact cache", "enabled", collectorCacheEnabled, "ttl", collectorCacheExpiresTTL, "compression", cacheCompressionEnabled)
+		logger.Info("collector host fact cache", "enabled", collectorCacheEnabled, "ttl", collectorCacheExpiresTTL, "compression", collectorCacheCompression)
 
 		cacheCfg := &cacheConfig{
 			Enabled:     collectorCacheEnabled,
@@ -275,7 +275,7 @@ func main() {
 			collectorCacheExpiresTTL = *collectorHostCacheExpiresTTL
 		}
 
-		logger.Info("collector host cache", "enabled", collectorCacheEnabled, "ttl", collectorCacheExpiresTTL, "compression", cacheCompressionEnabled)
+		logger.Info("collector host cache", "enabled", collectorCacheEnabled, "ttl", collectorCacheExpiresTTL, "compression", collectorCacheCompression)
 
 		cacheCfg := &cacheConfig{
 			Enabled:     collectorCacheEnabled,

--- a/ring.go
+++ b/ring.go
@@ -172,6 +172,11 @@ func SimpleMemberlistKV(instanceID, instanceAddr string, instancePort int, joinM
 	// other peers with at least one `joinMembers`.
 	if len(joinMembers) > 0 {
 		config.JoinMembers = joinMembers
+		// Retry the initial join so a node that starts before its peers (or
+		// before the SRV record resolves) keeps trying instead of running solo.
+		config.MinJoinBackoff = 1 * time.Second
+		config.MaxJoinBackoff = 1 * time.Minute
+		config.MaxJoinRetries = 10
 	}
 
 	// resolver defines how each peers IP address should be resolved.
@@ -185,8 +190,12 @@ func SimpleMemberlistKV(instanceID, instanceAddr string, instancePort int, joinM
 	config.GossipToTheDeadTime = 30 * time.Second
 	// Enable message compression, reduce bandwidth usage but slightly more CPU usage
 	config.EnableCompression = true
-	// Disable state push/pull syncs completely
-	config.PushPullInterval = 0 * time.Second
+	// Periodic anti-entropy full-state sync so nodes that missed gossip (blip,
+	// restart, transient partition) reconverge instead of staying split.
+	config.PushPullInterval = 30 * time.Second
+	// Periodically re-run the join against the seed nodes (JoinMembers, i.e. the
+	// dnssrv+ SRV record) so a node that lost the cluster can find it again.
+	config.RejoinInterval = 60 * time.Second
 
 	return memberlist.NewKVInitService(
 		&config,


### PR DESCRIPTION
Hotfixes for the v1.0.0 rollout that collapsed the production memberlist cluster (goroutines 25 → 8000+, RSS ~10x, `cluster_members_count` 3 → 1). Three separate commits:

### 1. Stop the zstd goroutine leak (the root cause)
The collectors created `zstd.NewReader`/`NewWriter` **per scrape and never `Close()`d** them. Each spawns GOMAXPROCS worker goroutines that live until Close, so every cache read/write leaked ~GOMAXPROCS goroutines. Fixed by reusing a single shared, concurrency-safe encoder/decoder (`EncodeAll`/`DecodeAll`).

Verified locally: goroutines stay flat (29 → 25 over 25 scrapes) where before they grew ~8/scrape.

### 2. Re-enable memberlist self-healing
`ring.go` hardcoded `PushPullInterval = 0`, disabling anti-entropy, and left `RejoinInterval` at 0. So once nodes lost each other (a restart or blip) they never reconverged. Re-enabled `PushPullInterval = 30s` (cheaper now that the cache is a protobuf value) + `RejoinInterval = 60s` and added join backoff/retries so a node re-resolves the seed SRV and rejoins.

### 3. Log the resolved cache compression bool
`compression` was logged as the `*bool` flag pointer (`0x…`) instead of the resolved value.

## Verification
`go build`, `go vet`, `go test ./...` (29 pass), golangci-lint v2 clean, and a live ring+cache+compression smoke run.

Suggest releasing this as **v1.0.1**.