### PR TITLE
feat: show the ring leader on the index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* [FEATURE] show the current ring leader on the index page when the ring is enabled
+* [FEATURE] index page: show the ring members and leader, exporter version, foreman url, and per-collector cache config; add a `/status` JSON endpoint; clearer section names and endpoint paths
 
 ## 1.0.0 / 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [FEATURE] show the current ring leader on the index page when the ring is enabled
+
 ## 1.0.0 / 2026-07-28
 
 * [CHANGE] go 1.26 and refresh all Go dependencies (dskit, prometheus/common v0.70, exporter-toolkit v0.17, client_golang v1.23)

--- a/handlers.go
+++ b/handlers.go
@@ -25,6 +25,36 @@ func newIndexPageContent() *IndexPageContent {
 
 type indexPageContents struct {
 	LinkGroups []IndexPageLinkGroup
+	Ring       ringStatus
+}
+
+// ringStatus is the ring leader information shown on the index page. It is
+// computed per request since leadership can change at any time.
+type ringStatus struct {
+	Enabled    bool
+	Leader     string // leader instance id
+	LeaderAddr string
+	IsSelf     bool
+	Err        string
+}
+
+// ringStatusFor resolves the current ring leader. When the ring is disabled it
+// returns a zero-value (Enabled=false); when the ring is up but no healthy
+// leader can be determined it returns the error for display.
+func ringStatusFor(r ExporterRing) ringStatus {
+	if !r.enabled {
+		return ringStatus{}
+	}
+	rl, err := ringLeader(r.client)
+	if err != nil {
+		return ringStatus{Enabled: true, Err: err.Error()}
+	}
+	return ringStatus{
+		Enabled:    true,
+		Leader:     rl.Id,
+		LeaderAddr: rl.Addr,
+		IsSelf:     rl.Addr == r.lifecycler.GetInstanceAddr(),
+	}
 }
 
 // IndexPageContent is a map of sections to path -> description.
@@ -80,7 +110,7 @@ func (pc *IndexPageContent) GetContent() []IndexPageLinkGroup {
 //go:embed static
 var staticFiles embed.FS
 
-func indexHandler(httpPathPrefix string, content *IndexPageContent) http.HandlerFunc {
+func indexHandler(httpPathPrefix string, content *IndexPageContent, ringCfg ExporterRing) http.HandlerFunc {
 	templ := template.New("main")
 	templ.Funcs(map[string]interface{}{
 		"AddPathPrefix": func(link string) string {
@@ -90,7 +120,10 @@ func indexHandler(httpPathPrefix string, content *IndexPageContent) http.Handler
 	template.Must(templ.Parse(indexPageHTML))
 
 	return func(w http.ResponseWriter, _ *http.Request) {
-		err := templ.Execute(w, indexPageContents{LinkGroups: content.GetContent()})
+		err := templ.Execute(w, indexPageContents{
+			LinkGroups: content.GetContent(),
+			Ring:       ringStatusFor(ringCfg),
+		})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/handlers.go
+++ b/handlers.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"encoding/json"
 	"html/template"
+	"net"
 	"net/http"
 	"path"
 	"sort"
@@ -64,6 +65,35 @@ type ringMember struct {
 	State  string `json:"state"`
 	Leader bool   `json:"leader"`
 	Self   bool   `json:"self"`
+	URL    string `json:"url,omitempty"`
+}
+
+// webURLForAddr builds a link to a member's own web UI. The ring address carries
+// the gossip port, so we swap in the port (and scheme) the client used to reach
+// this node, assuming every node exposes its UI on the same port.
+func webURLForAddr(r *http.Request, ringAddr string) string {
+	host, _, err := net.SplitHostPort(ringAddr)
+	if err != nil {
+		host = ringAddr
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if _, port, err := net.SplitHostPort(r.Host); err == nil && port != "" {
+		return scheme + "://" + net.JoinHostPort(host, port) + "/"
+	}
+	return scheme + "://" + host + "/"
+}
+
+// ringStatusForRequest resolves the ring status and fills each member's web-UI
+// URL based on the incoming request (scheme/port).
+func ringStatusForRequest(r *http.Request, ringCfg ExporterRing) ringStatus {
+	rs := ringStatusFor(ringCfg)
+	for i := range rs.Members {
+		rs.Members[i].URL = webURLForAddr(r, rs.Members[i].Addr)
+	}
+	return rs
 }
 
 // ringStatusFor resolves the current ring members and leader. When the ring is
@@ -162,14 +192,14 @@ func indexHandler(httpPathPrefix string, content *IndexPageContent, static pageS
 	})
 	template.Must(templ.Parse(indexPageHTML))
 
-	return func(w http.ResponseWriter, _ *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		err := templ.Execute(w, indexPageContents{
 			LinkGroups: content.GetContent(),
 			Version:    static.Version,
 			Revision:   static.Revision,
 			ForemanURL: static.ForemanURL,
 			Collectors: static.Collectors,
-			Ring:       ringStatusFor(ringCfg),
+			Ring:       ringStatusForRequest(r, ringCfg),
 		})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -180,7 +210,7 @@ func indexHandler(httpPathPrefix string, content *IndexPageContent, static pageS
 // statusHandler exposes the same version/config/ring information as the index
 // page, as JSON, for automation.
 func statusHandler(static pageStatic, ringCfg ExporterRing) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
@@ -195,7 +225,7 @@ func statusHandler(static pageStatic, ringCfg ExporterRing) http.HandlerFunc {
 			Revision:   static.Revision,
 			ForemanURL: static.ForemanURL,
 			Collectors: static.Collectors,
-			Ring:       ringStatusFor(ringCfg),
+			Ring:       ringStatusForRequest(r, ringCfg),
 		})
 	}
 }

--- a/handlers.go
+++ b/handlers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"html/template"
 	"net/http"
 	"path"
@@ -25,36 +26,78 @@ func newIndexPageContent() *IndexPageContent {
 
 type indexPageContents struct {
 	LinkGroups []IndexPageLinkGroup
+	Version    string
+	Revision   string
+	ForemanURL string
+	Collectors []collectorInfo
 	Ring       ringStatus
 }
 
-// ringStatus is the ring leader information shown on the index page. It is
-// computed per request since leadership can change at any time.
-type ringStatus struct {
-	Enabled    bool
-	Leader     string // leader instance id
-	LeaderAddr string
-	IsSelf     bool
-	Err        string
+// pageStatic holds the parts of the index page that don't change at runtime.
+// It is captured once when the handlers are built.
+type pageStatic struct {
+	Version    string
+	Revision   string
+	ForemanURL string
+	Collectors []collectorInfo
 }
 
-// ringStatusFor resolves the current ring leader. When the ring is disabled it
-// returns a zero-value (Enabled=false); when the ring is up but no healthy
-// leader can be determined it returns the error for display.
+// collectorInfo summarises an enabled collector's cache configuration.
+type collectorInfo struct {
+	Name         string `json:"name"`
+	CacheEnabled bool   `json:"cache_enabled"`
+	TTL          string `json:"ttl,omitempty"`
+	Compression  bool   `json:"compression"`
+}
+
+// ringStatus is the ring state shown on the index page. It is computed per
+// request since membership and leadership can change at any time.
+type ringStatus struct {
+	Enabled bool         `json:"enabled"`
+	Err     string       `json:"error,omitempty"`
+	Members []ringMember `json:"members,omitempty"`
+}
+
+type ringMember struct {
+	ID     string `json:"id"`
+	Addr   string `json:"addr"`
+	State  string `json:"state"`
+	Leader bool   `json:"leader"`
+	Self   bool   `json:"self"`
+}
+
+// ringStatusFor resolves the current ring members and leader. When the ring is
+// disabled it returns a zero value (Enabled=false); when the ring is up but the
+// members can't be listed it returns the error for display.
 func ringStatusFor(r ExporterRing) ringStatus {
 	if !r.enabled {
 		return ringStatus{}
 	}
-	rl, err := ringLeader(r.client)
+
+	leaderAddr := ""
+	if rl, err := ringLeader(r.client); err == nil {
+		leaderAddr = rl.Addr
+	}
+
+	rs, err := r.client.GetAllHealthy(ringOp)
 	if err != nil {
 		return ringStatus{Enabled: true, Err: err.Error()}
 	}
-	return ringStatus{
-		Enabled:    true,
-		Leader:     rl.Id,
-		LeaderAddr: rl.Addr,
-		IsSelf:     rl.Addr == r.lifecycler.GetInstanceAddr(),
+
+	self := r.lifecycler.GetInstanceAddr()
+	members := make([]ringMember, 0, len(rs.Instances))
+	for _, inst := range rs.Instances {
+		members = append(members, ringMember{
+			ID:     inst.Id,
+			Addr:   inst.Addr,
+			State:  inst.State.String(),
+			Leader: leaderAddr != "" && inst.Addr == leaderAddr,
+			Self:   inst.Addr == self,
+		})
 	}
+	sort.Slice(members, func(i, j int) bool { return members[i].ID < members[j].ID })
+
+	return ringStatus{Enabled: true, Members: members}
 }
 
 // IndexPageContent is a map of sections to path -> description.
@@ -110,7 +153,7 @@ func (pc *IndexPageContent) GetContent() []IndexPageLinkGroup {
 //go:embed static
 var staticFiles embed.FS
 
-func indexHandler(httpPathPrefix string, content *IndexPageContent, ringCfg ExporterRing) http.HandlerFunc {
+func indexHandler(httpPathPrefix string, content *IndexPageContent, static pageStatic, ringCfg ExporterRing) http.HandlerFunc {
 	templ := template.New("main")
 	templ.Funcs(map[string]interface{}{
 		"AddPathPrefix": func(link string) string {
@@ -122,11 +165,38 @@ func indexHandler(httpPathPrefix string, content *IndexPageContent, ringCfg Expo
 	return func(w http.ResponseWriter, _ *http.Request) {
 		err := templ.Execute(w, indexPageContents{
 			LinkGroups: content.GetContent(),
+			Version:    static.Version,
+			Revision:   static.Revision,
+			ForemanURL: static.ForemanURL,
+			Collectors: static.Collectors,
 			Ring:       ringStatusFor(ringCfg),
 		})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
+	}
+}
+
+// statusHandler exposes the same version/config/ring information as the index
+// page, as JSON, for automation.
+func statusHandler(static pageStatic, ringCfg ExporterRing) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(struct {
+			Version    string          `json:"version"`
+			Revision   string          `json:"revision"`
+			ForemanURL string          `json:"foreman_url"`
+			Collectors []collectorInfo `json:"collectors"`
+			Ring       ringStatus      `json:"ring"`
+		}{
+			Version:    static.Version,
+			Revision:   static.Revision,
+			ForemanURL: static.ForemanURL,
+			Collectors: static.Collectors,
+			Ring:       ringStatusFor(ringCfg),
+		})
 	}
 }
 

--- a/handlers.go
+++ b/handlers.go
@@ -52,11 +52,14 @@ type collectorInfo struct {
 }
 
 // ringStatus is the ring state shown on the index page. It is computed per
-// request since membership and leadership can change at any time.
+// request since membership and leadership can change at any time. The index page
+// only shows the leader; the full member list is kept for the /status endpoint.
 type ringStatus struct {
-	Enabled bool         `json:"enabled"`
-	Err     string       `json:"error,omitempty"`
-	Members []ringMember `json:"members,omitempty"`
+	Enabled   bool         `json:"enabled"`
+	Err       string       `json:"error,omitempty"`
+	Members   []ringMember `json:"members,omitempty"`
+	Leader    ringMember   `json:"-"`
+	HasLeader bool         `json:"-"`
 }
 
 type ringMember struct {
@@ -92,6 +95,10 @@ func ringStatusForRequest(r *http.Request, ringCfg ExporterRing) ringStatus {
 	rs := ringStatusFor(ringCfg)
 	for i := range rs.Members {
 		rs.Members[i].URL = webURLForAddr(r, rs.Members[i].Addr)
+		if rs.Members[i].Leader {
+			rs.Leader = rs.Members[i]
+			rs.HasLeader = true
+		}
 	}
 	return rs
 }

--- a/handlers.go
+++ b/handlers.go
@@ -71,14 +71,11 @@ type ringMember struct {
 	URL    string `json:"url,omitempty"`
 }
 
-// webURLForAddr builds a link to a member's own web UI. The ring address carries
-// the gossip port, so we swap in the port (and scheme) the client used to reach
-// this node, assuming every node exposes its UI on the same port.
-func webURLForAddr(r *http.Request, ringAddr string) string {
-	host, _, err := net.SplitHostPort(ringAddr)
-	if err != nil {
-		host = ringAddr
-	}
+// webURLForHost builds a link to a member's own web UI from its host (the
+// instance id, i.e. the FQDN). The ring address carries the gossip port, so we
+// swap in the port (and scheme) the client used to reach this node, assuming
+// every node exposes its UI on the same port.
+func webURLForHost(r *http.Request, host string) string {
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
@@ -90,11 +87,11 @@ func webURLForAddr(r *http.Request, ringAddr string) string {
 }
 
 // ringStatusForRequest resolves the ring status and fills each member's web-UI
-// URL based on the incoming request (scheme/port).
+// URL (using the member's FQDN) based on the incoming request (scheme/port).
 func ringStatusForRequest(r *http.Request, ringCfg ExporterRing) ringStatus {
 	rs := ringStatusFor(ringCfg)
 	for i := range rs.Members {
-		rs.Members[i].URL = webURLForAddr(r, rs.Members[i].Addr)
+		rs.Members[i].URL = webURLForHost(r, rs.Members[i].ID)
 		if rs.Members[i].Leader {
 			rs.Leader = rs.Members[i]
 			rs.HasLeader = true

--- a/index.gohtml
+++ b/index.gohtml
@@ -22,6 +22,23 @@
             <img alt="Foreman Exporter logo" class="foreman-brand" src="{{ AddPathPrefix "/static/foreman.png" }}">
         </div>
     </div>
+    {{ if .Ring.Enabled }}
+        <div class="row service-row border-bottom py-3">
+            <div class="col-sm-3 text-start text-sm-end"><h2>Cluster</h2></div>
+            <div class="col-sm-9">
+                {{ if .Ring.Err }}
+                    <span class="badge bg-warning text-dark">leader unknown</span>
+                    <span class="text-muted">{{ .Ring.Err }}</span>
+                {{ else }}
+                    <p class="my-0">
+                        Ring leader: <strong>{{ .Ring.Leader }}</strong>
+                        <span class="text-muted">({{ .Ring.LeaderAddr }})</span>
+                        {{ if .Ring.IsSelf }}<span class="badge bg-success ms-1">this instance</span>{{ end }}
+                    </p>
+                {{ end }}
+            </div>
+        </div>
+    {{ end }}
     {{ range $i, $ := .LinkGroups }}
         <div class="row service-row border-bottom py-3">
             <div class="col-sm-3 text-start text-sm-end"><h2>{{ $.Desc }}</h2></div>

--- a/index.gohtml
+++ b/index.gohtml
@@ -49,7 +49,6 @@
                     <p class="my-0">
                         {{ with .Ring.Leader }}
                             {{ if .URL }}<a href="{{ .URL }}">{{ .ID }}</a>{{ else }}{{ .ID }}{{ end }}
-                            {{ if .Self }}<span class="badge bg-success ms-1">this instance</span>{{ end }}
                         {{ end }}
                     </p>
                 {{ else }}

--- a/index.gohtml
+++ b/index.gohtml
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {{ if .Ring.Enabled }}<meta http-equiv="refresh" content="30">{{ end }}
 
     <title>Foreman Exporter</title>
 
@@ -16,36 +17,86 @@
 <div class="d-flex flex-column container py-3">
     <div class="header row border-bottom py-3 flex-column-reverse flex-sm-row">
         <div class="col-12 col-sm-9 text-center text-sm-start">
-            <h1>Foreman Exporter</h1>
+            <h1 class="mb-0">Foreman Exporter</h1>
+            {{ if .Version }}<span class="text-muted small">v{{ .Version }}{{ if .Revision }} ({{ .Revision }}){{ end }}</span>{{ end }}
         </div>
         <div class="col-12 col-sm-3 text-center text-sm-end mb-3 mb-sm-0">
             <img alt="Foreman Exporter logo" class="foreman-brand" src="{{ AddPathPrefix "/static/foreman.png" }}">
         </div>
     </div>
+
     {{ if .Ring.Enabled }}
         <div class="row service-row border-bottom py-3">
             <div class="col-sm-3 text-start text-sm-end"><h2>Cluster</h2></div>
             <div class="col-sm-9">
                 {{ if .Ring.Err }}
-                    <span class="badge bg-warning text-dark">leader unknown</span>
+                    <span class="badge bg-warning text-dark">ring unavailable</span>
                     <span class="text-muted">{{ .Ring.Err }}</span>
                 {{ else }}
-                    <p class="my-0">
-                        Ring leader: <strong>{{ .Ring.Leader }}</strong>
-                        <span class="text-muted">({{ .Ring.LeaderAddr }})</span>
-                        {{ if .Ring.IsSelf }}<span class="badge bg-success ms-1">this instance</span>{{ end }}
-                    </p>
+                    <table class="table table-sm align-middle mb-0">
+                        <thead>
+                            <tr><th>Instance</th><th>Address</th><th>State</th><th></th></tr>
+                        </thead>
+                        <tbody>
+                        {{ range .Ring.Members }}
+                            <tr>
+                                <td>{{ .ID }}</td>
+                                <td class="text-muted">{{ .Addr }}</td>
+                                <td>{{ .State }}</td>
+                                <td>
+                                    {{ if .Leader }}<span class="badge bg-primary">leader</span>{{ end }}
+                                    {{ if .Self }}<span class="badge bg-success">this instance</span>{{ end }}
+                                </td>
+                            </tr>
+                        {{ end }}
+                        </tbody>
+                    </table>
                 {{ end }}
             </div>
         </div>
     {{ end }}
+
+    <div class="row service-row border-bottom py-3">
+        <div class="col-sm-3 text-start text-sm-end"><h2>Foreman</h2></div>
+        <div class="col-sm-9"><p class="my-0 text-break">{{ .ForemanURL }}</p></div>
+    </div>
+
+    {{ if .Collectors }}
+        <div class="row service-row border-bottom py-3">
+            <div class="col-sm-3 text-start text-sm-end"><h2>Collectors</h2></div>
+            <div class="col-sm-9">
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr><th>Collector</th><th>Cache</th><th>TTL</th><th>Compression</th></tr>
+                    </thead>
+                    <tbody>
+                    {{ range .Collectors }}
+                        <tr>
+                            <td>{{ .Name }}</td>
+                            <td>
+                                {{ if .CacheEnabled }}<span class="badge bg-success">enabled</span>
+                                {{ else }}<span class="badge bg-secondary">disabled</span>{{ end }}
+                            </td>
+                            <td class="text-muted">{{ if .CacheEnabled }}{{ .TTL }}{{ else }}&mdash;{{ end }}</td>
+                            <td>{{ if .Compression }}zstd{{ else }}&mdash;{{ end }}</td>
+                        </tr>
+                    {{ end }}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {{ end }}
+
     {{ range $i, $ := .LinkGroups }}
         <div class="row service-row border-bottom py-3">
             <div class="col-sm-3 text-start text-sm-end"><h2>{{ $.Desc }}</h2></div>
             <div class="col-sm-9">
                 <ul class="my-0 list-unstyled">
                     {{ range $.Links }}
-                        <li><a href="{{ AddPathPrefix .Path }}">{{ .Desc }}</a></li>
+                        <li>
+                            <a href="{{ AddPathPrefix .Path }}">{{ .Desc }}</a>
+                            <span class="text-muted small">{{ .Path }}</span>
+                        </li>
                     {{ end }}
                 </ul>
             </div>

--- a/index.gohtml
+++ b/index.gohtml
@@ -25,80 +25,36 @@
         </div>
     </div>
 
-    {{ if .Ring.Enabled }}
-        <div class="row service-row border-bottom py-3">
-            <div class="col-sm-3 text-start text-sm-end"><h2>Cluster</h2></div>
-            <div class="col-sm-9">
-                {{ if .Ring.Err }}
-                    <span class="badge bg-warning text-dark">ring unavailable</span>
-                    <span class="text-muted">{{ .Ring.Err }}</span>
-                {{ else }}
-                    <table class="table table-sm align-middle mb-0">
-                        <thead>
-                            <tr><th>Instance</th><th>Address</th><th>State</th><th></th></tr>
-                        </thead>
-                        <tbody>
-                        {{ range .Ring.Members }}
-                            <tr>
-                                <td>{{ if .URL }}<a href="{{ .URL }}">{{ .ID }}</a>{{ else }}{{ .ID }}{{ end }}</td>
-                                <td class="text-muted">{{ .Addr }}</td>
-                                <td>{{ .State }}</td>
-                                <td>
-                                    {{ if .Leader }}<span class="badge bg-primary">leader</span>{{ end }}
-                                    {{ if .Self }}<span class="badge bg-success">this instance</span>{{ end }}
-                                </td>
-                            </tr>
-                        {{ end }}
-                        </tbody>
-                    </table>
-                {{ end }}
-            </div>
-        </div>
-    {{ end }}
-
-    <div class="row service-row border-bottom py-3">
-        <div class="col-sm-3 text-start text-sm-end"><h2>Foreman</h2></div>
-        <div class="col-sm-9"><p class="my-0 text-break">{{ .ForemanURL }}</p></div>
-    </div>
-
-    {{ if .Collectors }}
-        <div class="row service-row border-bottom py-3">
-            <div class="col-sm-3 text-start text-sm-end"><h2>Collectors</h2></div>
-            <div class="col-sm-9">
-                <table class="table table-sm align-middle mb-0">
-                    <thead>
-                        <tr><th>Collector</th><th>Cache</th><th>TTL</th><th>Compression</th></tr>
-                    </thead>
-                    <tbody>
-                    {{ range .Collectors }}
-                        <tr>
-                            <td>{{ .Name }}</td>
-                            <td>
-                                {{ if .CacheEnabled }}<span class="badge bg-success">enabled</span>
-                                {{ else }}<span class="badge bg-secondary">disabled</span>{{ end }}
-                            </td>
-                            <td class="text-muted">{{ if .CacheEnabled }}{{ .TTL }}{{ else }}&mdash;{{ end }}</td>
-                            <td>{{ if .Compression }}zstd{{ else }}&mdash;{{ end }}</td>
-                        </tr>
-                    {{ end }}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    {{ end }}
-
     {{ range $i, $ := .LinkGroups }}
         <div class="row service-row border-bottom py-3">
             <div class="col-sm-3 text-start text-sm-end"><h2>{{ $.Desc }}</h2></div>
             <div class="col-sm-9">
                 <ul class="my-0 list-unstyled">
                     {{ range $.Links }}
-                        <li>
-                            <a href="{{ AddPathPrefix .Path }}">{{ .Desc }}</a>
-                            <span class="text-muted small">{{ .Path }}</span>
-                        </li>
+                        <li><a href="{{ AddPathPrefix .Path }}">{{ .Path }}</a> &mdash; {{ .Desc }}</li>
                     {{ end }}
                 </ul>
+            </div>
+        </div>
+    {{ end }}
+
+    {{ if .Ring.Enabled }}
+        <div class="row service-row border-bottom py-3">
+            <div class="col-sm-3 text-start text-sm-end"><h2>Cluster Leader</h2></div>
+            <div class="col-sm-9">
+                {{ if .Ring.Err }}
+                    <span class="badge bg-warning text-dark">ring unavailable</span>
+                    <span class="text-muted">{{ .Ring.Err }}</span>
+                {{ else if .Ring.HasLeader }}
+                    <p class="my-0">
+                        {{ with .Ring.Leader }}
+                            {{ if .URL }}<a href="{{ .URL }}">{{ .ID }}</a>{{ else }}{{ .ID }}{{ end }}
+                            {{ if .Self }}<span class="badge bg-success ms-1">this instance</span>{{ end }}
+                        {{ end }}
+                    </p>
+                {{ else }}
+                    <span class="text-muted">no leader elected</span>
+                {{ end }}
             </div>
         </div>
     {{ end }}

--- a/index.gohtml
+++ b/index.gohtml
@@ -40,7 +40,7 @@
                         <tbody>
                         {{ range .Ring.Members }}
                             <tr>
-                                <td>{{ .ID }}</td>
+                                <td>{{ if .URL }}<a href="{{ .URL }}">{{ .ID }}</a>{{ else }}{{ .ID }}{{ end }}</td>
                                 <td class="text-muted">{{ .Addr }}</td>
                                 <td>{{ .State }}</td>
                                 <td>

--- a/main.go
+++ b/main.go
@@ -147,6 +147,9 @@ func main() {
 	indexPage.AddLinks(metricsWeight, "Metrics", []IndexPageLink{
 		{Desc: "Exported metrics", Path: "/metrics"},
 	})
+	indexPage.AddLinks(defaultWeight, "Status", []IndexPageLink{
+		{Desc: "Status (JSON)", Path: "/status"},
+	})
 	var ringConfig ExporterRing
 	if *ringEnabled {
 		ctx := context.Background()
@@ -160,11 +163,11 @@ func main() {
 			os.Exit(1)
 		}
 
-		indexPage.AddLinks(ringWeight, "Exporter", []IndexPageLink{
+		indexPage.AddLinks(ringWeight, "Ring", []IndexPageLink{
 			{Desc: "Ring status", Path: "/ring"},
 		})
 		indexPage.AddLinks(memberlistWeight, "Memberlist", []IndexPageLink{
-			{Desc: "Status", Path: "/memberlist"},
+			{Desc: "Membership status", Path: "/memberlist"},
 		})
 
 		http.Handle("/ring", ringConfig.lifecycler)
@@ -173,7 +176,7 @@ func main() {
 		localCache = memcache.NewLocalCache()
 	}
 
-	http.Handle("/", indexHandler("", indexPage, ringConfig))
+	var collectorsInfo []collectorInfo
 
 	client := foreman.NewHTTPClient(
 		*baseURL,
@@ -198,8 +201,8 @@ func main() {
 			logger.Warn("flags '--collector.hostfact.search' and '--collector.hostfact.include' and '--collector.hostfact.exclude' are not defined, it could cause big metrics labels !!")
 		}
 
-		indexPage.AddLinks(hostFactWeight, "Hosts Facts Metrics", []IndexPageLink{
-			{Desc: "Exported Host Facts metrics", Path: "/host-facts-metrics"},
+		indexPage.AddLinks(hostFactWeight, "Host facts", []IndexPageLink{
+			{Desc: "Scrape host facts", Path: "/host-facts-metrics"},
 		})
 
 		var collectorCacheEnabled bool
@@ -231,6 +234,13 @@ func main() {
 			ExpiresTTL:  time.Duration(collectorCacheExpiresTTL.Seconds()) * time.Second,
 		}
 
+		collectorsInfo = append(collectorsInfo, collectorInfo{
+			Name:         "hostfact",
+			CacheEnabled: collectorCacheEnabled,
+			TTL:          collectorCacheExpiresTTL.String(),
+			Compression:  collectorCacheCompression,
+		})
+
 		collector := HostFactCollector{
 			Client:        client,
 			Logger:        logger,
@@ -250,8 +260,8 @@ func main() {
 
 		logger.Info("collector host enabled")
 
-		indexPage.AddLinks(hostWeight, "Hosts Metrics", []IndexPageLink{
-			{Desc: "Exported Host metrics", Path: "/host-metrics"},
+		indexPage.AddLinks(hostWeight, "Host", []IndexPageLink{
+			{Desc: "Scrape host metrics", Path: "/host-metrics"},
 		})
 
 		var collectorCacheEnabled bool
@@ -283,6 +293,13 @@ func main() {
 			ExpiresTTL:  time.Duration(collectorCacheExpiresTTL.Seconds()) * time.Second,
 		}
 
+		collectorsInfo = append(collectorsInfo, collectorInfo{
+			Name:         "host",
+			CacheEnabled: collectorCacheEnabled,
+			TTL:          collectorCacheExpiresTTL.String(),
+			Compression:  collectorCacheCompression,
+		})
+
 		collector := HostCollector{
 			Client:                client,
 			Logger:                logger,
@@ -299,6 +316,15 @@ func main() {
 			hostHandler(w, req, collector)
 		})
 	}
+
+	static := pageStatic{
+		Version:    version.Version,
+		Revision:   version.Revision,
+		ForemanURL: (*baseURL).Redacted(),
+		Collectors: collectorsInfo,
+	}
+	http.Handle("/", indexHandler("", indexPage, static, ringConfig))
+	http.Handle("/status", statusHandler(static, ringConfig))
 
 	server := &http.Server{
 		ReadTimeout:       120 * time.Second,

--- a/main.go
+++ b/main.go
@@ -145,10 +145,10 @@ func main() {
 
 	indexPage := newIndexPageContent()
 	indexPage.AddLinks(metricsWeight, "Metrics", []IndexPageLink{
-		{Desc: "Exported metrics", Path: "/metrics"},
+		{Desc: "exporter & foreman client metrics", Path: "/metrics"},
 	})
 	indexPage.AddLinks(defaultWeight, "Status", []IndexPageLink{
-		{Desc: "Status (JSON)", Path: "/status"},
+		{Desc: "status as JSON", Path: "/status"},
 	})
 	var ringConfig ExporterRing
 	if *ringEnabled {
@@ -163,11 +163,9 @@ func main() {
 			os.Exit(1)
 		}
 
-		indexPage.AddLinks(ringWeight, "Ring", []IndexPageLink{
-			{Desc: "Ring status", Path: "/ring"},
-		})
-		indexPage.AddLinks(memberlistWeight, "Memberlist", []IndexPageLink{
-			{Desc: "Membership status", Path: "/memberlist"},
+		indexPage.AddLinks(ringWeight, "Cluster", []IndexPageLink{
+			{Desc: "ring members & token distribution", Path: "/ring"},
+			{Desc: "gossip KV store status", Path: "/memberlist"},
 		})
 
 		http.Handle("/ring", ringConfig.lifecycler)
@@ -202,7 +200,7 @@ func main() {
 		}
 
 		indexPage.AddLinks(hostFactWeight, "Host facts", []IndexPageLink{
-			{Desc: "Scrape host facts", Path: "/host-facts-metrics"},
+			{Desc: "scrape host facts", Path: "/host-facts-metrics"},
 		})
 
 		var collectorCacheEnabled bool
@@ -261,7 +259,7 @@ func main() {
 		logger.Info("collector host enabled")
 
 		indexPage.AddLinks(hostWeight, "Host", []IndexPageLink{
-			{Desc: "Scrape host metrics", Path: "/host-metrics"},
+			{Desc: "scrape host metrics", Path: "/host-metrics"},
 		})
 
 		var collectorCacheEnabled bool

--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ func main() {
 		localCache = memcache.NewLocalCache()
 	}
 
-	http.Handle("/", indexHandler("", indexPage))
+	http.Handle("/", indexHandler("", indexPage, ringConfig))
 
 	client := foreman.NewHTTPClient(
 		*baseURL,


### PR DESCRIPTION
Adds cluster/leader visibility to the exporter's home page and a JSON status endpoint.

## Index page
- **Cluster Leader** entry showing the leader's FQDN, linked to that node's own web UI (uses the FQDN + the scheme/port the client used to reach this node, assuming a uniform web port).
- **Cluster** link group merging `/ring` (ring members & token distribution) and `/memberlist` (gossip KV store status).
- Exporter **version** in the header; endpoint links now show their path.
- Auto-refresh (30s) when the ring is enabled.

## /status JSON endpoint
Machine-readable status for automation: version, foreman url, per-collector cache config, and the full ring member list (id, addr, state, leader, self).

## Verification
`go build`, `go vet`, `go test ./...` (29 pass), golangci-lint v2 clean, and a live ring smoke run confirming the leader entry and links.