### PR TITLE
feat: measure collector scrape duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* [FEATURE] add `foreman_exporter_host_scrape_duration_seconds` and `foreman_exporter_host_facts_scrape_duration_seconds` gauges (and log the duration on cache update) to measure how long a full collector scrape takes
 * [FEATURE] index page: show the ring members and leader, exporter version, foreman url, and per-collector cache config; add a `/status` JSON endpoint; clearer section names and endpoint paths
 
 ## 1.0.0 / 2026-07-28

--- a/host_collector.go
+++ b/host_collector.go
@@ -17,6 +17,11 @@ import (
 var (
 	hostsKey          = "collectors/host"
 	hostCollectorLock = make(chan struct{}, 1)
+
+	hostScrapeDurationMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "foreman_exporter_host_scrape_duration_seconds",
+		Help: "Duration of the last completed host collector scrape of foreman.",
+	})
 )
 
 type HostCollector struct {
@@ -140,6 +145,7 @@ func (c HostCollector) Collect(ch chan<- prometheus.Metric) {
 
 		// use a goroutine to get result in async mode
 		go func() {
+			start := time.Now()
 
 			if *collectorsLock {
 				// lock and return directly if another request is in progress
@@ -190,6 +196,9 @@ func (c HostCollector) Collect(ch chan<- prometheus.Metric) {
 					hostsData = append(hostsData, labels)
 				}
 
+				elapsed := time.Since(start)
+				hostScrapeDurationMetric.Set(elapsed.Seconds())
+
 				// Add to the cache
 				if c.RingConfig.enabled && c.CacheConfig.Enabled {
 					content, _ := json.Marshal(hostsData)
@@ -199,12 +208,12 @@ func (c HostCollector) Collect(ch chan<- prometheus.Metric) {
 					}
 					if hostStatusError == nil {
 						// update the cache
-						c.Logger.Info(fmt.Sprintf("updating cache key '%s'", hostsKey))
+						c.Logger.Info(fmt.Sprintf("updating cache key '%s'", hostsKey), "duration", elapsed.String())
 						c.updateKV(content)
 					}
 				} else if c.CacheConfig.Enabled {
 					// update the local cache
-					c.Logger.Info(fmt.Sprintf("updating cache key '%s'", hostsKey))
+					c.Logger.Info(fmt.Sprintf("updating cache key '%s'", hostsKey), "duration", elapsed.String())
 					localCache.Set(hostsKey, hostsData, c.CacheConfig.ExpiresTTL)
 				}
 			}

--- a/hostfact_collector.go
+++ b/hostfact_collector.go
@@ -17,6 +17,11 @@ import (
 var (
 	hostsFactsKey          = "collectors/host-fact"
 	hostFactsCollectorLock = make(chan struct{}, 1)
+
+	hostFactScrapeDurationMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "foreman_exporter_host_facts_scrape_duration_seconds",
+		Help: "Duration of the last completed host facts collector scrape of foreman.",
+	})
 )
 
 type HostFactCollector struct {
@@ -124,6 +129,7 @@ func (c HostFactCollector) Collect(ch chan<- prometheus.Metric) {
 
 		// use a goroutine to get result in async mode
 		go func() {
+			start := time.Now()
 
 			if *collectorsLock {
 				// lock and return directly if another request is in progress
@@ -160,6 +166,9 @@ func (c HostFactCollector) Collect(ch chan<- prometheus.Metric) {
 					hostsData = append(hostsData, labels)
 				}
 
+				elapsed := time.Since(start)
+				hostFactScrapeDurationMetric.Set(elapsed.Seconds())
+
 				// Add to the cache
 				if c.RingConfig.enabled && c.CacheConfig.Enabled {
 					content, _ := json.Marshal(hostsData)
@@ -169,12 +178,12 @@ func (c HostFactCollector) Collect(ch chan<- prometheus.Metric) {
 					}
 					if hostsFactsError == nil {
 						// update the cache
-						c.Logger.Info(fmt.Sprintf("updating cache key '%s'", hostsFactsKey))
+						c.Logger.Info(fmt.Sprintf("updating cache key '%s'", hostsFactsKey), "duration", elapsed.String())
 						c.updateKV(content)
 					}
 				} else if c.CacheConfig.Enabled {
 					// update the local cache
-					c.Logger.Info(fmt.Sprintf("updating cache key '%s'", hostsFactsKey))
+					c.Logger.Info(fmt.Sprintf("updating cache key '%s'", hostsFactsKey), "duration", elapsed.String())
 					localCache.Set(hostsFactsKey, hostsData, c.CacheConfig.ExpiresTTL)
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -195,6 +195,8 @@ func main() {
 
 		logger.Info("collector host fact enabled")
 
+		prometheus.MustRegister(hostFactScrapeDurationMetric)
+
 		if *collectorHostFactSearch == "" && *collectorHostFactIncludeRegex == nil && *collectorHostFactExcludeRegex == nil {
 			logger.Warn("flags '--collector.hostfact.search' and '--collector.hostfact.include' and '--collector.hostfact.exclude' are not defined, it could cause big metrics labels !!")
 		}
@@ -257,6 +259,8 @@ func main() {
 	if slices.Contains(*collectorsEnabled, "host") {
 
 		logger.Info("collector host enabled")
+
+		prometheus.MustRegister(hostScrapeDurationMetric)
 
 		indexPage.AddLinks(hostWeight, "Host", []IndexPageLink{
 			{Desc: "scrape host metrics", Path: "/host-metrics"},


### PR DESCRIPTION
Adds visibility into how long a full collector scrape of Foreman actually takes — which is unrelated to the Prometheus scrape timeout, since the collectors run the real scrape asynchronously and serve the (possibly expired) cache within the timeout.

## Change
- New gauges set when the async scrape completes:
  - `foreman_exporter_host_scrape_duration_seconds`
  - `foreman_exporter_host_facts_scrape_duration_seconds`
- The `updating cache key '…'` log line now carries the duration, e.g. `duration=3m48s`.

This lets operators size `--cache.ttl-expires` and `--concurrency` against the real scrape cost (e.g. ~4 min for ~8400 hosts) instead of guessing from the timeout logs.

## Verification
`go build`, `go vet`, `go test ./...` (29 pass), golangci-lint v2 clean; the gauge is registered per enabled collector and set on scrape completion.