### PR TITLE
release: 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## Unreleased
+## 1.1.0 / 2026-07-28
 
+* [BUGFIX] stop a goroutine/memory leak by reusing a shared zstd encoder/decoder instead of creating one (never closed) per scrape, which exhausted the process and collapsed the memberlist cluster under load
+* [BUGFIX] re-enable memberlist anti-entropy (`PushPullInterval`) and add periodic rejoin so nodes reconverge after a restart or transient network blip instead of staying split
+* [BUGFIX] log the resolved cache compression bool instead of the flag pointer
 * [FEATURE] add `foreman_exporter_host_scrape_duration_seconds` and `foreman_exporter_host_facts_scrape_duration_seconds` gauges (and log the duration on cache update) to measure how long a full collector scrape takes
 * [FEATURE] index page: show the ring members and leader, exporter version, foreman url, and per-collector cache config; add a `/status` JSON endpoint; clearer section names and endpoint paths
 


### PR DESCRIPTION
Cut the **1.1.0** release: renames the CHANGELOG `Unreleased` section to `1.1.0 / 2026-07-28`.

1.1.0 gathers everything merged since 1.0.0:
- **[BUGFIX]** stop the zstd goroutine/memory leak that collapsed the memberlist cluster under load
- **[BUGFIX]** re-enable memberlist anti-entropy + periodic rejoin so nodes reconverge
- **[BUGFIX]** log the resolved cache compression bool (not the flag pointer)
- **[FEATURE]** collector scrape-duration gauges + duration in the cache-update log
- **[FEATURE]** index page shows the ring leader/members, version, foreman url, per-collector cache config; `/status` JSON endpoint; clearer names

(minor bump rather than 1.0.1 since it includes new features.)

After merge, tagging `v1.1.0` on main triggers `publish_release`.