### PR TITLE
fix: expose full memberlist config via CLI, stop zeroing transport timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* [BUGFIX] stop zeroing the memberlist TCP transport timeouts: the whole `TCPTransportConfig` was being replaced, leaving `MaxConcurrentWrites`=1 and `AcquireWriterTimeout`=0, which dropped probe ACKs/gossip on high-latency (cross-DC) links and made the cluster flap (`no acks received` / health score pegged). Bind addr/port are now merged into the existing transport config.
+* [CHANGE] expose the full dskit memberlist KV config on the CLI under `--ring.memberlist.*` (gossip, probe, push/pull, rejoin, join-backoff, transport timeouts, …) instead of hardcoded values; tune them per environment. Note: `stream-timeout` and `rejoin-interval` now default to dskit values (2s and 0) — set `--ring.memberlist.stream-timeout`/`--ring.memberlist.rejoin-interval` (and, for cross-DC, `--ring.memberlist.max-concurrent-writes` / `--ring.memberlist.acquire-writer-timeout`) as needed.
+
 ## 1.1.0 / 2026-07-28
 
 * [BUGFIX] stop a goroutine/memory leak by reusing a shared zstd encoder/decoder instead of creating one (never closed) per scrape, which exhausted the process and collapsed the memberlist cluster under load

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 * [BUGFIX] stop zeroing the memberlist TCP transport timeouts: the whole `TCPTransportConfig` was being replaced, leaving `MaxConcurrentWrites`=1 and `AcquireWriterTimeout`=0, which dropped probe ACKs/gossip on high-latency (cross-DC) links and made the cluster flap (`no acks received` / health score pegged). Bind addr/port are now merged into the existing transport config.
-* [CHANGE] expose the full dskit memberlist KV config on the CLI under `--ring.memberlist.*` (gossip, probe, push/pull, rejoin, join-backoff, transport timeouts, …) instead of hardcoded values; tune them per environment. Note: `stream-timeout` and `rejoin-interval` now default to dskit values (2s and 0) — set `--ring.memberlist.stream-timeout`/`--ring.memberlist.rejoin-interval` (and, for cross-DC, `--ring.memberlist.max-concurrent-writes` / `--ring.memberlist.acquire-writer-timeout`) as needed.
+* [CHANGE] expose the full dskit memberlist KV config on the CLI under `--ring.memberlist.*` (gossip, probe, push/pull, rejoin, join-backoff, transport timeouts, …) and the ring lifecycler settings `--ring.heartbeat-period`, `--ring.heartbeat-timeout`, `--ring.keep-instance-in-ring-on-shutdown`, instead of hardcoded values; tune them per environment. Note: `stream-timeout` and `rejoin-interval` now default to dskit values (2s and 0) — set `--ring.memberlist.stream-timeout`/`--ring.memberlist.rejoin-interval` (and, for cross-DC, `--ring.memberlist.max-concurrent-writes` / `--ring.memberlist.acquire-writer-timeout`) as needed.
 
 ## 1.1.0 / 2026-07-28
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -12,6 +13,8 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -76,6 +79,11 @@ var (
 	ringInstanceInterfaceNames = kingpin.Flag("ring.instance-interface-names", "List of network interface names to look up when finding the instance IP address.").String()
 	ringJoinMembers            = kingpin.Flag("ring.join-members", "Other cluster members to join.").String()
 
+	// ringMemberlistKV exposes the whole dskit memberlist KV config on the CLI
+	// (flags registered in main, under the "ring.memberlist." prefix) so every
+	// gossip/transport parameter is tunable per environment instead of hardcoded.
+	ringMemberlistKV memberlist.KVConfig
+
 	localCache *memcache.MemCache
 
 	labelNameRegexp = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
@@ -118,6 +126,28 @@ func main() {
 
 	promslogConfig := &promslog.Config{}
 	promslogflag.AddFlags(kingpin.CommandLine, promslogConfig)
+
+	// Bridge the whole dskit memberlist KV config into kingpin: register it on a
+	// stdlib FlagSet, then mirror each flag into kingpin (a stdlib flag.Value
+	// satisfies kingpin.Value). This exposes every memberlist gossip/transport
+	// parameter under "--ring.memberlist.*". Flags already covered by the
+	// exporter's own ring flags are skipped to avoid duplicates.
+	flagext.DefaultValues(&ringMemberlistKV)
+	mlFlagSet := flag.NewFlagSet("memberlist", flag.ContinueOnError)
+	ringMemberlistKV.RegisterFlagsWithPrefix(mlFlagSet, "ring.")
+	mlSkip := map[string]bool{
+		"ring.memberlist.join":      true, // covered by --ring.join-members
+		"ring.memberlist.nodename":  true, // covered by --ring.instance-id
+		"ring.memberlist.bind-addr": true, // covered by --ring.instance-addr
+		"ring.memberlist.bind-port": true, // covered by --ring.instance-port
+	}
+	mlFlagSet.VisitAll(func(f *flag.Flag) {
+		if mlSkip[f.Name] {
+			return
+		}
+		kingpin.Flag(f.Name, f.Usage).Default(f.DefValue).SetValue(f.Value)
+	})
+
 	kingpin.Version(version.Print("foreman-exporter"))
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
@@ -153,7 +183,7 @@ func main() {
 	var ringConfig ExporterRing
 	if *ringEnabled {
 		ctx := context.Background()
-		ringConfig, err = newRing(*ringInstanceID, *ringInstanceAddr, *ringJoinMembers, *ringInstanceInterfaceNames, *ringInstancePort, newGoKitLogger(logger))
+		ringConfig, err = newRing(*ringInstanceID, *ringInstanceAddr, *ringJoinMembers, *ringInstanceInterfaceNames, *ringInstancePort, ringMemberlistKV, newGoKitLogger(logger))
 		defer services.StopAndAwaitTerminated(ctx, ringConfig.memberlistsvc) //nolint:errcheck
 		defer services.StopAndAwaitTerminated(ctx, ringConfig.lifecycler)    //nolint:errcheck
 		defer services.StopAndAwaitTerminated(ctx, ringConfig.client)        //nolint:errcheck

--- a/main.go
+++ b/main.go
@@ -79,6 +79,10 @@ var (
 	ringInstanceInterfaceNames = kingpin.Flag("ring.instance-interface-names", "List of network interface names to look up when finding the instance IP address.").String()
 	ringJoinMembers            = kingpin.Flag("ring.join-members", "Other cluster members to join.").String()
 
+	ringHeartbeatPeriod              = kingpin.Flag("ring.heartbeat-period", "Period at which to heartbeat to the ring.").Default("15s").Duration()
+	ringHeartbeatTimeout             = kingpin.Flag("ring.heartbeat-timeout", "Heartbeat timeout after which ring instances are assumed unhealthy.").Default("30s").Duration()
+	ringKeepInstanceInRingOnShutdown = kingpin.Flag("ring.keep-instance-in-ring-on-shutdown", "Keep the instance in the ring on shutdown (removed later by auto-forget).").Default("true").Bool()
+
 	// ringMemberlistKV exposes the whole dskit memberlist KV config on the CLI
 	// (flags registered in main, under the "ring.memberlist." prefix) so every
 	// gossip/transport parameter is tunable per environment instead of hardcoded.
@@ -183,7 +187,12 @@ func main() {
 	var ringConfig ExporterRing
 	if *ringEnabled {
 		ctx := context.Background()
-		ringConfig, err = newRing(*ringInstanceID, *ringInstanceAddr, *ringJoinMembers, *ringInstanceInterfaceNames, *ringInstancePort, ringMemberlistKV, newGoKitLogger(logger))
+		lifecyclerCfg := RingLifecyclerConfig{
+			HeartbeatPeriod:                 *ringHeartbeatPeriod,
+			HeartbeatTimeout:                *ringHeartbeatTimeout,
+			KeepInstanceInTheRingOnShutdown: *ringKeepInstanceInRingOnShutdown,
+		}
+		ringConfig, err = newRing(*ringInstanceID, *ringInstanceAddr, *ringJoinMembers, *ringInstanceInterfaceNames, *ringInstancePort, ringMemberlistKV, lifecyclerCfg, newGoKitLogger(logger))
 		defer services.StopAndAwaitTerminated(ctx, ringConfig.memberlistsvc) //nolint:errcheck
 		defer services.StopAndAwaitTerminated(ctx, ringConfig.lifecycler)    //nolint:errcheck
 		defer services.StopAndAwaitTerminated(ctx, ringConfig.client)        //nolint:errcheck

--- a/ring.go
+++ b/ring.go
@@ -32,12 +32,17 @@ const (
 	// unhealthy instance in the ring will be automatically removed after.
 	ringAutoForgetUnhealthyPeriods = 3
 
-	heartbeatPeriod  = 15 * time.Second
-	heartbeatTimeout = 30 * time.Second
-
 	// leaderToken is the special token that makes the owner the ring leader.
 	leaderToken = 0
 )
+
+// RingLifecyclerConfig holds the ring lifecycler settings exposed on the CLI
+// (see main.go), instead of hardcoded values.
+type RingLifecyclerConfig struct {
+	HeartbeatPeriod                 time.Duration
+	HeartbeatTimeout                time.Duration
+	KeepInstanceInTheRingOnShutdown bool
+}
 
 // ringOp is used as an instance state filter when obtaining instances from the
 // ring. Instances in the LEAVING state are included to help minimise the number
@@ -55,7 +60,7 @@ type ExporterRing struct {
 	jsonClient    *memberlist.Client
 }
 
-func newRing(instanceID, instanceAddr, joinMembers, instanceInterfaceNames string, instancePort int, mlKVConfig memberlist.KVConfig, logger log.Logger) (ExporterRing, error) {
+func newRing(instanceID, instanceAddr, joinMembers, instanceInterfaceNames string, instancePort int, mlKVConfig memberlist.KVConfig, lifecyclerCfg RingLifecyclerConfig, logger log.Logger) (ExporterRing, error) {
 	var config ExporterRing
 	ctx := context.Background()
 
@@ -102,7 +107,7 @@ func newRing(instanceID, instanceAddr, joinMembers, instanceInterfaceNames strin
 		return config, err
 	}
 
-	lfc, err := SimpleRingLifecycler(ringClient, instanceID, instanceAddr, instancePort, instanceInterfaceNamesSlice, logger, reg)
+	lfc, err := SimpleRingLifecycler(ringClient, instanceID, instanceAddr, instancePort, instanceInterfaceNamesSlice, lifecyclerCfg, logger, reg)
 	if err != nil {
 		return config, err
 	}
@@ -193,7 +198,7 @@ func SimpleMemberlistKV(config memberlist.KVConfig, instanceID, instanceAddr str
 
 // SimpleRingLifecycler returns an instance lifecycler for the given `kv.Client`.
 // Usually lifecycler will be part of the server side that act as a single peer.
-func SimpleRingLifecycler(store kv.Client, instanceID, instanceAddr string, instancePort int, instanceInterfaceNames []string, logger log.Logger, reg prometheus.Registerer) (*ring.BasicLifecycler, error) {
+func SimpleRingLifecycler(store kv.Client, instanceID, instanceAddr string, instancePort int, instanceInterfaceNames []string, cfg RingLifecyclerConfig, logger log.Logger, reg prometheus.Registerer) (*ring.BasicLifecycler, error) {
 	var config ring.BasicLifecyclerConfig
 	instanceAddr, err := ring.GetInstanceAddr(instanceAddr, instanceInterfaceNames, logger, false)
 	if err != nil {
@@ -202,17 +207,17 @@ func SimpleRingLifecycler(store kv.Client, instanceID, instanceAddr string, inst
 
 	config.ID = instanceID
 	config.Addr = fmt.Sprintf("%s:%d", instanceAddr, instancePort)
-	config.HeartbeatPeriod = heartbeatPeriod
-	config.HeartbeatTimeout = heartbeatTimeout
+	config.HeartbeatPeriod = cfg.HeartbeatPeriod
+	config.HeartbeatTimeout = cfg.HeartbeatTimeout
 	config.TokensObservePeriod = 0
 	config.NumTokens = ringNumTokens
-	config.KeepInstanceInTheRingOnShutdown = true
+	config.KeepInstanceInTheRingOnShutdown = cfg.KeepInstanceInTheRingOnShutdown
 
 	var delegate ring.BasicLifecyclerDelegate
 
 	delegate = ring.NewInstanceRegisterDelegate(ring.ACTIVE, ringNumTokens)
 	delegate = ring.NewLeaveOnStoppingDelegate(delegate, logger)
-	delegate = ring.NewAutoForgetDelegate(ringAutoForgetUnhealthyPeriods*heartbeatPeriod, delegate, logger)
+	delegate = ring.NewAutoForgetDelegate(ringAutoForgetUnhealthyPeriods*cfg.HeartbeatPeriod, delegate, logger)
 
 	return ring.NewBasicLifecycler(
 		config,

--- a/ring.go
+++ b/ring.go
@@ -55,7 +55,7 @@ type ExporterRing struct {
 	jsonClient    *memberlist.Client
 }
 
-func newRing(instanceID, instanceAddr, joinMembers, instanceInterfaceNames string, instancePort int, logger log.Logger) (ExporterRing, error) {
+func newRing(instanceID, instanceAddr, joinMembers, instanceInterfaceNames string, instancePort int, mlKVConfig memberlist.KVConfig, logger log.Logger) (ExporterRing, error) {
 	var config ExporterRing
 	ctx := context.Background()
 
@@ -82,7 +82,7 @@ func newRing(instanceID, instanceAddr, joinMembers, instanceInterfaceNames strin
 	reg = prometheus.WrapRegistererWithPrefix("foreman_exporter_", reg)
 
 	// start memberlist service.
-	memberlistsvc := SimpleMemberlistKV(instanceID, instanceAddr, instancePort, joinMembersSlice, logger, reg)
+	memberlistsvc := SimpleMemberlistKV(mlKVConfig, instanceID, instanceAddr, instancePort, joinMembersSlice, logger, reg)
 	if err := services.StartAndAwaitRunning(ctx, memberlistsvc); err != nil {
 		return config, err
 	}
@@ -152,50 +152,36 @@ func SimpleRing(store kv.Client, logger log.Logger, reg prometheus.Registerer) (
 // SimpleMemberlistKV returns a memberlist KV as a service. Starting and Stopping the service is upto the caller.
 // Caller can create an instance `kv.Client` from returned service by explicity calling `.GetMemberlistKV()`
 // which can be used as dependency to create a ring or ring lifecycler.
-func SimpleMemberlistKV(instanceID, instanceAddr string, instancePort int, joinMembers []string, logger log.Logger, reg prometheus.Registerer) *memberlist.KVInitService {
-	var config memberlist.KVConfig
-	flagext.DefaultValues(&config)
+func SimpleMemberlistKV(config memberlist.KVConfig, instanceID, instanceAddr string, instancePort int, joinMembers []string, logger log.Logger, reg prometheus.Registerer) *memberlist.KVInitService {
+	// config already carries every memberlist setting from the CLI flags (with
+	// dskit defaults). Only override what is specific to this exporter.
 
-	// Codecs is used to tell memberlist library how to serialize/de-serialize the messages between peers.
-	// `ring.GetCode()` uses default, which is protobuf.
+	// Codecs tell the memberlist library how to (de)serialize messages between
+	// peers. `ring.GetCodec()` uses protobuf.
 	config.Codecs = []codec.Codec{ring.GetCodec(), cacheCodec}
 
-	// TCPTransport defines what addr and port this particular peer should listen for.
-	config.TCPTransport = memberlist.TCPTransportConfig{
-		BindPort:  instancePort,
-		BindAddrs: []string{instanceAddr},
-	}
+	// Set the listen addr/port on the EXISTING transport config. Replacing the
+	// whole TCPTransportConfig would zero the transport timeouts (dial, write,
+	// max-concurrent-writes, acquire-writer-timeout); with those at zero,
+	// MaxConcurrentWrites clamps to a single writer and AcquireWriterTimeout=0
+	// drops any packet that can't grab that slot instantly — on a high-latency
+	// (cross-DC) link that silently drops probe ACKs and gossip and makes the
+	// cluster flap. Those values now come from the CLI flags.
+	config.TCPTransport.BindPort = instancePort
+	config.TCPTransport.BindAddrs = []string{instanceAddr}
 
-	// joinMembers is the address of peer who is already in the memberlist group.
-	// Usually be provided if this peer is trying to join existing cluster.
-	// Generally you start very first peer without `joinMembers`, but start every
-	// other peers with at least one `joinMembers`.
+	// The ring instance id is authoritative for the memberlist node name.
+	config.NodeName = instanceID
+
+	// joinMembers comes from --ring.join-members (the dnssrv+ SRV record).
 	if len(joinMembers) > 0 {
 		config.JoinMembers = joinMembers
-		// Retry the initial join so a node that starts before its peers (or
-		// before the SRV record resolves) keeps trying instead of running solo.
-		config.MinJoinBackoff = 1 * time.Second
-		config.MaxJoinBackoff = 1 * time.Minute
-		config.MaxJoinRetries = 10
 	}
 
-	// resolver defines how each peers IP address should be resolved.
-	// We use default resolver comes with Go.
+	// resolver defines how each peer's IP address should be resolved.
 	// maxIdleConnections is only used by the miekgdns resolver; the golang
 	// resolver ignores it.
 	resolver := dns.NewProvider(dns.GolangResolverType, 0, log.With(logger, "component", "dns"), reg)
-
-	config.NodeName = instanceID
-	config.StreamTimeout = 10 * time.Second
-	config.GossipToTheDeadTime = 30 * time.Second
-	// Enable message compression, reduce bandwidth usage but slightly more CPU usage
-	config.EnableCompression = true
-	// Periodic anti-entropy full-state sync so nodes that missed gossip (blip,
-	// restart, transient partition) reconverge instead of staying split.
-	config.PushPullInterval = 30 * time.Second
-	// Periodically re-run the join against the seed nodes (JoinMembers, i.e. the
-	// dnssrv+ SRV record) so a node that lost the cluster can find it again.
-	config.RejoinInterval = 60 * time.Second
 
 	return memberlist.NewKVInitService(
 		&config,


### PR DESCRIPTION
## Root cause
`SimpleMemberlistKV` replaced the **whole** `memberlist.TCPTransportConfig` (setting only BindPort/BindAddrs), which zeroed the transport timeouts. With them at zero, dskit clamps `MaxConcurrentWrites` to **1** and `AcquireWriterTimeout=0` **drops any packet that can't grab that single write slot instantly**. On a high-latency link the single writer is frequently busy, so probe ACKs and gossip get dropped, which shows up as `no acks received` suspicion, constant suspect/refute churn, and an elevated memberlist health score. (This became visible once push/pull + rejoin were enabled, adding write traffic that saturated the single slot; the metric help is explicit: "not sent due to timeout waiting for a writer".)

## Change
- **Merge** BindPort/BindAddrs into the existing `TCPTransport` instead of replacing it, so the transport timeouts are no longer zeroed.
- **Expose the whole dskit memberlist KV config on the CLI** under `--ring.memberlist.*` (gossip, probe, push/pull, rejoin, join-backoff, transport timeouts, ...). Implemented by registering dskit's `KVConfig.RegisterFlagsWithPrefix` on a stdlib `flag.FlagSet` and mirroring each flag into kingpin (a `flag.Value` satisfies `kingpin.Value`). `join`, `nodename`, `bind-addr`, `bind-port` are skipped (covered by the existing `--ring.*` flags).
- **Expose the ring lifecycler settings** `--ring.heartbeat-period`, `--ring.heartbeat-timeout`, `--ring.keep-instance-in-ring-on-shutdown` (same defaults as before).

This removes the previously hardcoded ring/memberlist values so every parameter is tunable per environment. Note: `stream-timeout` and `rejoin-interval` now use dskit defaults (2s, 0) rather than the previously hardcoded 10s/60s.

## Verification
`go build`, `go vet`, `go test ./...`, golangci-lint v2 clean; the memberlist and ring-lifecycler flags appear in `--help`, and a live startup with several set responds on `/ring` + `/memberlist`.
