### PR TITLE
release: 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.2.0 / 2026-07-28
 
 * [BUGFIX] stop zeroing the memberlist TCP transport timeouts: the whole `TCPTransportConfig` was being replaced, leaving `MaxConcurrentWrites`=1 and `AcquireWriterTimeout`=0, which dropped probe ACKs/gossip on high-latency (cross-DC) links and made the cluster flap (`no acks received` / health score pegged). Bind addr/port are now merged into the existing transport config.
 * [CHANGE] expose the full dskit memberlist KV config on the CLI under `--ring.memberlist.*` (gossip, probe, push/pull, rejoin, join-backoff, transport timeouts, …) and the ring lifecycler settings `--ring.heartbeat-period`, `--ring.heartbeat-timeout`, `--ring.keep-instance-in-ring-on-shutdown`, instead of hardcoded values; tune them per environment. Note: `stream-timeout` and `rejoin-interval` now default to dskit values (2s and 0) — set `--ring.memberlist.stream-timeout`/`--ring.memberlist.rejoin-interval` (and, for cross-DC, `--ring.memberlist.max-concurrent-writes` / `--ring.memberlist.acquire-writer-timeout`) as needed.


### PR DESCRIPTION
Cut the **1.2.0** release: renames the CHANGELOG `Unreleased` section to `1.2.0 / 2026-07-28`.

1.2.0 gathers, since 1.1.0:
- **[BUGFIX]** stop zeroing the memberlist TCP transport timeouts (fixes cluster flapping / dropped gossip on high-latency links)
- **[CHANGE]** expose the full memberlist KV config (`--ring.memberlist.*`) and ring lifecycler settings (`--ring.heartbeat-*`, `--ring.keep-instance-in-ring-on-shutdown`) on the CLI instead of hardcoded values

After merge, tagging `v1.2.0` on main triggers `publish_release`.